### PR TITLE
Updating Python 2.x syntax to be aligned with Python 3.x

### DIFF
--- a/OpenGLContext/pygamecontext.py
+++ b/OpenGLContext/pygamecontext.py
@@ -9,9 +9,9 @@ try:
     import pygame.key
     import pygame.display
 except ImportError:
-    raise ImportError, "The pygame package is required for the Pygame GL Context"
+    raise ImportError("The pygame package is required for the Pygame GL Context")
 if pygame.ver < '1.1':
-    raise ImportError, "Pygame v1.1 or greater is required for the Pygame GL Context"
+    raise ImportError("Pygame v1.1 or greater is required for the Pygame GL Context")
 
 #import opengl stuff
 from OpenGL.GL import *


### PR DESCRIPTION
This changes updates the Python 2.x exception raising syntax in one file to be Python 3.x conforming.

This fixes issue
https://github.com/mcfletch/openglcontext/issues/1